### PR TITLE
feat: theme.ts 및 폰트 초기 설정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <!-- CDN for Pretendard -->
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -90,6 +90,7 @@ video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
+  font-family: Pretendard;
 }
 /* HTML5 display-role reset for older browsers */
 article,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,5 +1,59 @@
-const colors = {};
+const colors = {
+  primary: '#FE5489',
+  primaryLight: '#FF8BA8',
+  primaryDark: '#D43966',
+  grayLight: '#84868D',
+  grayDark: '#303133',
+  success: '#10B981',
+  warning: '#FBBF24',
+  error: '#EF4444',
+  neutral50: '#F8FAFC',
+  neutral100: '#F1F5F9',
+  neutral200: '#E2E8F0',
+  neutral300: '#CBD5E1',
+  neutral400: '#94A3B8',
+  neutral500: '#64748B',
+  neutral600: '#475569',
+  neutral700: '#334155',
+  neutral800: '#1E293B',
+  neutral900: '#0F172A',
+  modalBackground: '#00000048',
+  bronze: '#C96344',
+  silver: '#C6C6C6',
+  gold: '#EBC700',
+  diamond: '#06CBBA',
+  master: '#FF033E',
+  kakao: '#FEE500',
+};
+
+const fontSize = {
+  xs: '10px',
+  sm: '13px',
+  md: '16px',
+  lg: '20px',
+  xl: '24px',
+  h4: '20px',
+  h3: '24px',
+  h2: '28px',
+  h1: '36px',
+};
+
+const fontWeight = {
+  light: 200,
+  regular: 400,
+  bold: 700,
+  header: 800,
+};
+
+const borderRadius = {
+  xs: '10px',
+  sm: '15px',
+  md: '30px',
+};
 
 export const theme = {
   colors,
+  fontSize,
+  fontWeight,
+  borderRadius,
 };


### PR DESCRIPTION
1. theme.ts에 초기 설정을 추가했습니다. 아래와 같이 컴포넌트에서 `import`하시면 사용 가능합니다.

```javascript
import styled from 'styled-components';
import { theme } from './styles/theme';

const ThemeTest = styled.div`
  color: ${theme.colors.primary};
  font-size: ${theme.fontSize.h1};
  font-weight: ${theme.fontWeight.bold};
`;

export const Test = () => {
  return (
    <div>
      <ThemeTest>hi</ThemeTest>
    </div>
  );
};
```
2. 웹 폰트를 사용해서 Pretendard를 기본 폰트로 설정했습니다. 폰트 파일을 로컬로 추가할지 cdn 값으로 적용할지 고민했는데, 만약 성능이 좋지 않다면 로컬로 적용하는 방식으로 전환하는 것도 고려해보겠습니다.